### PR TITLE
Catch route middleware exceptions

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -42,7 +42,7 @@ class Router {
         }
       }
 
-      // Lets check for a default Controller/Action math
+      // Lets check for a default Controller/Action match
       var regex = XRegExp('^/(?<controller>(?:[^\\WA-Z][\\w]*/)*[A-Z][\\w\\\\]*)/?(?<action>\\w+)?/?(?<params>[^\\?]+)?\\??.*$');
       let matches = regex.xexec(req.path);
       if (matches && matches.controller && matches.action) {
@@ -119,7 +119,12 @@ class Router {
         }
 
         if (route.middleware) {
-          yield Router.callMiddleware(context, route.middleware);
+          try {
+            yield Router.callMiddleware(context, route.middleware);
+          } catch (e) {
+            sand.error('Middleware exception:', e);
+            context.serverError('Middleware exception.');
+          }
         }
 
         let action = controller[context.actionName];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sand-http",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Sand HTTP Module ES6",
   "main": "lib/Http.js",
   "scripts": {


### PR DESCRIPTION
Exceptions from route middleware were causing unexpected HTTP responses. This ensures the exceptions are logged and a 500 is raised.